### PR TITLE
add --test option

### DIFF
--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -29,6 +29,7 @@ sub new {
 sub parse_options {
     my $self = shift;
     local @ARGV = @_;
+    $self->{notest} = 1;
     GetOptions
         "L|local-lib-contained=s" => \($self->{local_lib}),
         "V|version" => sub { $self->cmd_version },
@@ -38,6 +39,7 @@ sub parse_options {
         "mirror=s" => \($self->{mirror}),
         "v|verbose" => \($self->{verbose}),
         "w|workers=i" => \($self->{workers}),
+        "test!" => sub { $self->{notest} = $_[1] ? 0 : 1 },
     or exit 1;
 
     $self->{local_lib} = abs_path $self->{local_lib} unless $self->{global};
@@ -129,6 +131,7 @@ sub cmd_install {
             read_fh => $read_fh, write_fh => $write_fh,
             ($self->{global} ? () : (local_lib => $self->{local_lib})),
             menlo_base => $menlo_base, menlo_build_log => $menlo_build_log,
+            notest => $self->{notest},
         );
         $worker->run_loop;
     };

--- a/script/cpm
+++ b/script/cpm
@@ -37,6 +37,8 @@ cpm - a fast cpan module installer
         base url for the cpan mirror to use, default: http://www.cpan.org
       --color, --no-color
         turn on/off color output, default: on
+      --test, --no-test
+        run test cases, default: no
   -V, --version
         show version
   -h, --help

--- a/xt/10_basic.t
+++ b/xt/10_basic.t
@@ -37,4 +37,16 @@ subtest invalid_meta => sub {
     like $r->err, qr/^DONE install WWW-LinkedIn/;
 };
 
+subtest test => sub {
+    # File-pushd only in test requires
+    my $r = cpm_install "Distribution::Metadata";
+    unlike $r->err, qr/File-pushd/;
+
+    $r = cpm_install "--no-test", "Distribution::Metadata";
+    unlike $r->err, qr/File-pushd/;
+
+    $r = cpm_install "--test", "Distribution::Metadata";
+    like $r->err, qr/File-pushd/;
+};
+
 done_testing;


### PR DESCRIPTION
Addresses @ichesnokov's #14 
This PR introduces `--test` option, which makes cpm run tests of cpan modules.

Example:
```
> perl -Ilib script/cpm install -v --test Plack
48768 DONE resolve   (0.082sec) Plack -> Plack-1.0039
48770 DONE fetch     (0.833sec) Plack-1.0039
48769 DONE resolve   (0.114sec) File::ShareDir::Install -> File-ShareDir-Install-0.10
48772 DONE fetch     (0.398sec) File-ShareDir-Install-0.10
48771 DONE configure (0.190sec) File-ShareDir-Install-0.10
48768 DONE install   (1.949sec) File-ShareDir-Install-0.10
48770 DONE configure (0.358sec) Plack-1.0039
48769 DONE resolve   (0.201sec) Filesys::Notify::Simple -> Filesys-Notify-Simple-0.12
48768 DONE resolve   (0.201sec) Try::Tiny -> Try-Tiny-0.24
48772 DONE resolve   (0.316sec) HTTP::Body -> HTTP-Body-1.22
48769 DONE resolve   (0.114sec) Stream::Buffered -> Stream-Buffered-0.03
48771 DONE resolve   (0.316sec) Hash::MultiValue -> Hash-MultiValue-0.16
48770 DONE resolve   (0.317sec) File::ShareDir -> File-ShareDir-1.102
48768 DONE resolve   (0.116sec) HTTP::Message -> HTTP-Message-6.11
48772 DONE resolve   (0.149sec) Devel::StackTrace -> Devel-StackTrace-2.00
48771 DONE resolve   (0.149sec) HTTP::Headers::Fast -> HTTP-Headers-Fast-0.20
48769 DONE resolve   (0.150sec) Cookie::Baker -> Cookie-Baker-0.06
48770 DONE resolve   (0.150sec) Test::Requires -> Test-Requires-0.10
48768 DONE resolve   (0.149sec) Apache::LogFormat::Compiler -> Apache-LogFormat-Compiler-0.32
48772 DONE resolve   (0.134sec) Test::TCP -> Test-TCP-2.14
48771 DONE resolve   (0.135sec) Devel::StackTrace::AsHTML -> Devel-StackTrace-AsHTML-0.14
48768 DONE resolve   (0.134sec) URI -> URI-1.69
48770 DONE fetch     (0.419sec) Test-Requires-0.10
48769 DONE fetch     (0.486sec) Devel-StackTrace-2.00
48772 DONE fetch     (0.426sec) Stream-Buffered-0.03
48771 DONE fetch     (0.437sec) HTTP-Body-1.22
48768 DONE fetch     (0.444sec) Hash-MultiValue-0.16
48770 DONE fetch     (0.526sec) HTTP-Headers-Fast-0.20
48769 DONE fetch     (0.534sec) File-ShareDir-1.102
48771 DONE fetch     (0.481sec) Filesys-Notify-Simple-0.12
48768 DONE fetch     (0.489sec) Apache-LogFormat-Compiler-0.32
48772 DONE fetch     (0.566sec) Try-Tiny-0.24
48769 DONE configure (0.174sec) Test-Requires-0.10
48770 DONE fetch     (0.424sec) HTTP-Message-6.11
48769 DONE configure (0.185sec) HTTP-Body-1.22
48772 DONE configure (0.286sec) Devel-StackTrace-2.00
48768 DONE fetch     (0.408sec) Cookie-Baker-0.06
48770 DONE configure (0.173sec) Stream-Buffered-0.03
48769 DONE configure (0.192sec) File-ShareDir-1.102
48769 DONE configure (0.170sec) Hash-MultiValue-0.16
48771 DONE resolve   (0.799sec) Module::Build -> Module-Build-0.4214
48768 DONE fetch     (0.483sec) Test-TCP-2.14
48770 DONE fetch     (0.422sec) Devel-StackTrace-AsHTML-0.14
48772 DONE fetch     (0.560sec) URI-1.69
48770 DONE resolve   (0.053sec) Test::Deep -> Test-Deep-1.120
48771 DONE configure (0.219sec) Filesys-Notify-Simple-0.12
48771 DONE resolve   (0.055sec) Class::Inspector -> Class-Inspector-1.28
48770 DONE configure (0.263sec) HTTP-Message-6.11
48768 DONE configure (0.562sec) Try-Tiny-0.24
48769 DONE install   (0.795sec) Stream-Buffered-0.03
48768 DONE fetch     (0.346sec) Class-Inspector-1.28
48768 DONE resolve   (0.047sec) IO::HTML -> IO-HTML-1.001
48771 DONE install   (1.004sec) Hash-MultiValue-0.16
48770 DONE install   (0.870sec) Test-Requires-0.10
48768 DONE configure (0.229sec) Test-TCP-2.14
48768 DONE resolve   (0.047sec) Encode::Locale -> Encode-Locale-1.05
48772 DONE install   (1.439sec) Devel-StackTrace-2.00
48770 DONE fetch     (0.373sec) Module-Build-0.4214
48772 DONE resolve   (0.047sec) Test::SharedFork -> Test-SharedFork-0.34
48771 DONE fetch     (0.441sec) Test-Deep-1.120
48772 DONE resolve   (0.024sec) LWP::MediaTypes -> LWP-MediaTypes-6.02
48768 DONE configure (0.308sec) URI-1.69
48771 DONE resolve   (0.030sec) HTTP::Date -> HTTP-Date-6.02
48769 DONE install   (1.194sec) Try-Tiny-0.24
48772 DONE configure (0.226sec) Module-Build-0.4214
48770 DONE configure (0.354sec) Devel-StackTrace-AsHTML-0.14
48768 DONE fetch     (0.367sec) Test-SharedFork-0.34
48771 DONE fetch     (0.369sec) Encode-Locale-1.05
48769 DONE configure (0.253sec) Test-Deep-1.120
48772 DONE configure (0.327sec) Class-Inspector-1.28
48771 DONE configure (0.189sec) Test-SharedFork-0.34
48770 DONE fetch     (0.445sec) LWP-MediaTypes-6.02
48768 DONE fetch     (0.415sec) IO-HTML-1.001
48770 DONE configure (0.193sec) Encode-Locale-1.05
48768 DONE fetch     (0.391sec) HTTP-Date-6.02
48771 DONE install   (0.770sec) Devel-StackTrace-AsHTML-0.14
48768 DONE configure (0.317sec) IO-HTML-1.001
48770 DONE install   (0.889sec) Class-Inspector-1.28
48770 DONE configure (0.210sec) LWP-MediaTypes-6.02
48768 DONE install   (0.867sec) Encode-Locale-1.05
48768 DONE configure (0.188sec) HTTP-Date-6.02
48769 DONE install   (2.340sec) URI-1.69
48769 DONE install   (0.717sec) LWP-MediaTypes-6.02
48768 DONE install   (1.039sec) File-ShareDir-1.102
48768 DONE install   (0.666sec) HTTP-Date-6.02
48769 DONE install   (0.894sec) IO-HTML-1.001
48770 DONE install   (2.468sec) Test-Deep-1.120
48768 DONE install   (1.394sec) HTTP-Message-6.11
48769 DONE install   (1.415sec) HTTP-Body-1.22
48771 DONE install   (41.693sec) Test-SharedFork-0.34
48772 DONE install   (45.006sec) Module-Build-0.4214
48772 DONE configure (0.278sec) Cookie-Baker-0.06
48771 DONE configure (0.282sec) HTTP-Headers-Fast-0.20
48769 DONE configure (0.291sec) Apache-LogFormat-Compiler-0.32
48772 DONE resolve   (0.038sec) Test::Time -> Test-Time-0.04
48769 DONE resolve   (0.029sec) POSIX::strftime::Compiler -> POSIX-strftime-Compiler-0.41
48771 DONE resolve   (0.031sec) Test::MockTime -> Test-MockTime-0.15
48771 DONE fetch     (0.300sec) Test-MockTime-0.15
48772 DONE fetch     (0.344sec) Test-Time-0.04
48772 DONE configure (0.161sec) Test-MockTime-0.15
48771 DONE fetch     (0.314sec) POSIX-strftime-Compiler-0.41
48769 DONE install   (0.760sec) HTTP-Headers-Fast-0.20
48772 DONE configure (0.358sec) Test-Time-0.04
48772 DONE resolve   (0.028sec) Test::Name::FromLine -> Test-Name-FromLine-0.13
48771 DONE configure (0.290sec) POSIX-strftime-Compiler-0.41
48772 DONE fetch     (0.353sec) Test-Name-FromLine-0.13
48772 DONE configure (0.283sec) Test-Name-FromLine-0.13
48772 DONE resolve   (0.059sec) Test::Fatal -> Test-Fatal-0.014
48772 DONE resolve   (0.052sec) File::Slurp -> File-Slurp-9999.19
48772 DONE resolve   (0.022sec) Test::Differences -> Test-Differences-0.64
48771 DONE install   (0.885sec) POSIX-strftime-Compiler-0.41
48772 DONE fetch     (0.303sec) File-Slurp-9999.19
48771 DONE fetch     (0.354sec) Test-Differences-0.64
48771 DONE configure (0.149sec) Test-Differences-0.64
48772 DONE fetch     (0.333sec) Test-Fatal-0.014
48772 DONE resolve   (0.025sec) Text::Diff -> Text-Diff-1.43
48771 DONE configure (0.164sec) File-Slurp-9999.19
48771 DONE resolve   (0.063sec) Capture::Tiny -> Capture-Tiny-0.30
48772 DONE configure (0.254sec) Test-Fatal-0.014
48771 DONE fetch     (0.316sec) Text-Diff-1.43
48771 DONE fetch     (0.351sec) Capture-Tiny-0.30
48771 DONE install   (0.780sec) Test-Fatal-0.014
48771 DONE configure (0.192sec) Capture-Tiny-0.30
48771 DONE configure (0.164sec) Text-Diff-1.43
48772 DONE install   (4.000sec) File-Slurp-9999.19
48772 DONE resolve   (0.066sec) Algorithm::Diff -> Algorithm-Diff-1.1903
48772 DONE fetch     (0.708sec) Algorithm-Diff-1.1903
48772 DONE configure (0.211sec) Algorithm-Diff-1.1903
48772 DONE install   (0.721sec) Algorithm-Diff-1.1903
48768 DONE install   (11.442sec) Test-TCP-2.14
48772 DONE install   (0.821sec) Text-Diff-1.43
48770 DONE install   (13.804sec) Filesys-Notify-Simple-0.12
48769 DONE install   (28.777sec) Test-MockTime-0.15
48768 DONE install   (0.839sec) Apache-LogFormat-Compiler-0.32
48771 DONE install   (48.062sec) Capture-Tiny-0.30
48770 DONE install   (1.186sec) Test-Differences-0.64
48769 DONE install   (0.874sec) Test-Name-FromLine-0.13
48772 DONE install   (1.597sec) Test-Time-0.04
48768 DONE install   (0.599sec) Cookie-Baker-0.06
48770 DONE install   (12.651sec) Plack-1.0039
35 distributions installed.
perl -Ilib script/cpm install -v --test Plack  103.12s user 53.68s system 126% cpu 2:03.90 total
```

Random thoughts:
* This makes cpm significantly slow.
Actually I used to think testing culture of perl was good thing.
But as I wrote perl a lot, I came to think fastness is much more valuable than running tests.
Do not run tests in end user environment and let's concentrate on your writing perl code itself! cf: http://www.openswartz.com/2012/01/31/stop-running-tests-on-install/
* Let's look at ~/.perl-cpm/build.*.log. Can you see what tests are failed?