### PR TITLE
introduce --target-perl option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ perl:
   - '5.12'
   - '5.10'
   - '5.8'
+install:
+  - cpanm -nq --installdeps --with-develop .
 script:
   - prove -l t xt
 sudo: false

--- a/META.json
+++ b/META.json
@@ -31,7 +31,9 @@
       },
       "develop" : {
          "requires" : {
+            "Capture::Tiny" : "0",
             "Dist::Milla" : "v1.0.15",
+            "Path::Tiny" : "0",
             "Test::Pod" : "1.41"
          }
       },
@@ -53,12 +55,11 @@
             "Module::Metadata" : "0",
             "local::lib" : "2.000018",
             "perl" : "5.008005",
-            "version" : "0"
+            "version" : "0.77"
          }
       },
       "test" : {
          "requires" : {
-            "Capture::Tiny" : "0",
             "Test::More" : "0.96"
          }
       }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,10 +35,9 @@ my %WriteMakefileArgs = (
     "Module::CoreList" => 0,
     "Module::Metadata" => 0,
     "local::lib" => "2.000018",
-    "version" => 0
+    "version" => "0.77"
   },
   "TEST_REQUIRES" => {
-    "Capture::Tiny" => 0,
     "Test::More" => "0.96"
   },
   "VERSION" => "0.112",
@@ -53,7 +52,6 @@ my %FallbackPrereqs = (
   "CPAN::Meta" => 0,
   "CPAN::Meta::Requirements" => 0,
   "CPAN::Meta::YAML" => 0,
-  "Capture::Tiny" => 0,
   "ExtUtils::Install" => "1.46",
   "ExtUtils::MakeMaker" => "6.58",
   "File::pushd" => 0,
@@ -66,7 +64,7 @@ my %FallbackPrereqs = (
   "Module::Metadata" => 0,
   "Test::More" => "0.96",
   "local::lib" => "2.000018",
-  "version" => 0
+  "version" => "0.77"
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ requires 'Module::CPANfile';
 requires 'Module::CoreList';
 requires 'Module::Metadata';
 requires 'local::lib', '2.000018';
-requires 'version';
+requires 'version', '0.77';
 
 requires 'Menlo::CLI::Compat';
 
@@ -22,5 +22,9 @@ requires 'ExtUtils::Install', '1.46';   # shipt after perl v5.10.1
 
 on test => sub {
     requires 'Test::More', '0.96';
+};
+
+on develop => sub {
     requires 'Capture::Tiny';
+    requires 'Path::Tiny';
 };

--- a/script/cpm
+++ b/script/cpm
@@ -17,11 +17,18 @@ cpm - a fast cpan module installer
   # install modules
   > cpm install Module1 Module2 ...
 
+  # install modules with verbose messages
+  > cpm install -v Module
+
   # from cpanfile (with cpanfile.snapshot if any)
   > cpm install
 
   # install module to global @INC istead of local/lib/perl5
   > cpm install -g Module
+
+  # install modules as if version of your perl is 5.8.5
+  # so that modules which are not core in 5.8.5 will be installed
+  > cpm install --target-perl 5.8.5
 
 =head1 OPTIONS
 
@@ -33,6 +40,8 @@ cpm - a fast cpan module installer
         install modules to global @INC instead of local-lib
   -v, --verbose
         verbose mode; you can see what is going on
+      --target-perl=VERSION  (EXPERIMENTAL)
+        install modules as if verison is your perl is VERSION
       --mirror=URL
         base url for the cpan mirror to use, default: http://www.cpan.org
       --color, --no-color

--- a/xt/11_target_perl.t
+++ b/xt/11_target_perl.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use xt::CLI;
+use File::pushd 'tempd';
+use Path::Tiny;
+use version;
+
+my $perl_version = version->parse($])->numify;
+
+subtest test1 => sub {
+    plan skip_all => 'only for perl 5.22' unless 5.022 <= $perl_version && $perl_version < 5.023;
+    my $guard = tempd;
+    path("cpanfile")->spew(qq{requires "Module::Build";\n});
+    my $r = cpm_install "--target-perl", "5.10.1";
+    like $r->err, qr/WARN Module::Build used to be core/;
+    is $r->exit, 0;
+    note $r->err;
+};
+
+subtest test2 => sub {
+    plan skip_all => 'only for perl 5.12+' unless 5.012 <= $perl_version;
+    my $guard = tempd;
+    path("cpanfile")->spew(qq{requires 'HTTP::Tinyish';\n});
+    my $r = cpm_install "--target-perl", "5.8.5";
+    is $r->exit, 0;
+    like $r->err, qr/DONE install parent-/;
+    note $r->err;
+};
+
+subtest test3 => sub {
+    plan skip_all => 'only for perl 5.12+' unless 5.012 <= $perl_version;
+    my $guard = tempd;
+    path("cpanfile")->spew(qq{requires 'HTTP::Tinyish';\n});
+    my $r = cpm_install "--target-perl", "5.10.1";
+    is $r->exit, 0;
+    unlike $r->err, qr/DONE install parent-/;
+    note $r->err;
+};
+
+done_testing;

--- a/xt/CLI.pm
+++ b/xt/CLI.pm
@@ -5,7 +5,11 @@ use utf8;
 use Capture::Tiny 'capture';
 use File::Temp 'tempdir';
 use Exporter 'import';
+use FindBin '$Bin';
+use Cwd 'abs_path';
 our @EXPORT = qw(cpm_install with_same_local);
+
+my $base = abs_path("$Bin/..");
 
 my $TEMPDIR = tempdir CLEANUP => 1;
 
@@ -34,7 +38,7 @@ sub cpm_install {
     my @argv = @_;
     my $local = $_LOCAL || tempdir DIR => $TEMPDIR;
     my ($out, $err, $exit) = capture {
-        system $^X, "-Ilib", "script/cpm", "install", "-L", $local, @argv;
+        system $^X, "-I$base/lib", "$base/script/cpm", "install", "-L", $local, @argv;
     };
     Result->new(local => $local, out => $out, err => $err, exit => $exit);
 }


### PR DESCRIPTION
retake #9 

Introduce --target-perl option.

Eg:
```
$ perl -v
This is perl 5, version 22, subversion 1 (v5.22.1) built for darwin-2level

$ cat cpanfile
requires 'HTTP::Tinyish';

$ cpm install --target-perl 5.8.5
Loading modules from cpanfile...
DONE install HTTP-Tiny-0.056
DONE install IPC-Run3-0.048
DONE install parent-0.234 <==== parent module is not core in 5.8.5, so is installed
DONE install File-Which-1.19
DONE install HTTP-Tinyish-0.07
5 distributions installed.
```

This option may be useful when you generate a fatpacked script which supports old perls.

